### PR TITLE
dplyr 1.0.8: avoid matrices in filter()

### DIFF
--- a/R/plotMRF_hm.R
+++ b/R/plotMRF_hm.R
@@ -144,10 +144,10 @@ plotMRF_hm = function(MRF_mod, node_names, main, plot_observed_vals, data){
    label <- matrix(NA, n_nodes, n_nodes)
     for(i in seq_len(n_nodes)){
       for(j in 2:n_nodes){
-        label[i, j] <- nrow(data %>% dplyr::filter(data[, i] == 1 & data[,j] == 1))
+        label[i, j] <- nrow(data %>% dplyr::filter(data[, i, drop = TRUE] == 1 & data[,j, drop = TRUE] == 1))
       }
 
-      label[i, i] <- nrow(data %>% dplyr::filter(data[, i] == 1 &
+      label[i, i] <- nrow(data %>% dplyr::filter(data[, i, drop = TRUE] == 1 &
                                             rowSums(data[, c(seq_len(n_nodes)[-i])]) == 0))
     }
 


### PR DESCRIPTION
We're about to release dplyr 1.0.8 and as part of our rev dep checks, we've identified a problem with `MRFcov`. 

This is because `filter()` no longer supports matrix results. This pull request addresses this. 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘MRFcov-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: plotMRF_hm
  > ### Title: Plot MRF interaction parameters as a heatmap
  > ### Aliases: plotMRF_hm
  > 
  > ### ** Examples
  > 
  > 
  > data("Bird.parasites")
  > CRFmod <- MRFcov(data = Bird.parasites, n_nodes = 4, family = 'binomial')
  Leave-one-out cv used for the following low-occurrence (rare) nodes:
   Microfilaria ...
  Fitting MRF models in sequence using 1 core ...
  > plotMRF_hm(MRF_mod = CRFmod)
  > plotMRF_hm(MRF_mod = CRFmod, plot_observed_vals = TRUE, data = Bird.parasites)
  Error: Problem while computing `..1 = data[, i] == 1 & data[, j] == 1`.
  ✖ Input `..1` must be a logical vector, not a logical[,1].
  Backtrace:
       ▆
    1. ├─MRFcov::plotMRF_hm(...)
    2. │ ├─base::nrow(...)
    3. │ └─data %>% dplyr::filter(data[, i] == 1 & data[, j] == 1)
    4. ├─dplyr::filter(., data[, i] == 1 & data[, j] == 1)
    5. ├─dplyr:::filter.data.frame(., data[, i] == 1 & data[, j] == 1)
    6. │ └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
    7. │   └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
    8. │     ├─base::withCallingHandlers(...)
    9. │     └─mask$eval_all_filter(dots, env_filter)
   10. ├─dplyr:::dplyr_internal_error(...)
   11. │ └─rlang::abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
   12. │   └─rlang:::signal_abort(cnd, .file)
   13. │     └─base::signalCondition(cnd)
   14. └─dplyr `<fn>`(`<dpl:::__>`)
  Execution halted

1 error x | 0 warnings ✓ | 0 notes ✓
````